### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/io.github.pwr_solaar.solaar.yaml
+++ b/io.github.pwr_solaar.solaar.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.pwr_solaar.solaar
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: solaar
 rename-icon: solaar


### PR DESCRIPTION
tested with `flatpak run io.github.pwr_solaar.solaar`