### PR TITLE
chore: bump runtime to gnome 50

### DIFF
--- a/io.github.pwr_solaar.solaar.yaml
+++ b/io.github.pwr_solaar.solaar.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.pwr_solaar.solaar
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: solaar
 rename-icon: solaar


### PR DESCRIPTION
is generally functional on my G502 SE Hero

@tulilirockz 