### PR TITLE
Fix dark theme not working on KDE

### DIFF
--- a/io.github.pwr_solaar.solaar.yaml
+++ b/io.github.pwr_solaar.solaar.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --talk-name=org.gtk.vfs.*
   - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-run/gvfsd
+  - --filesystem=xdg-config/gtk-3.0/settings.ini:ro
   # --restart-on-wake-up support (https://github.com/flathub/io.github.pwr_solaar.solaar/issues/7)
   - --system-talk-name=org.freedesktop.UPower
   - --system-talk-name=org.freedesktop.login1


### PR DESCRIPTION
Fixes my own issue: https://github.com/flathub/io.github.pwr_solaar.solaar/issues/61

I spent some time investigating this issue and adding `- --filesystem=xdg-config/gtk-3.0/settings.ini:ro` to Flatpak permissions would fix the problem for KDE.

<img width="773" height="455" alt="Image" src="https://github.com/user-attachments/assets/71a7a7d5-093f-48a1-8a9c-6ffa28d667da" />

Relevant link: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/work_items/1362
The MR got closed because patching the runtime globally is too broad.

I tested this patch on Ubuntu 26.04 and no regression there (works fine with/without patch):
<img width="883" height="378" alt="Image" src="https://github.com/user-attachments/assets/2b6aa856-30fa-4a3b-b3a1-d276b14b4690" />