### PR TITLE
Fix generic Wayland icon on KDE

### DIFF
--- a/fix-icon.patch
+++ b/fix-icon.patch
@@ -1,3 +1,18 @@
+diff --git a/lib/solaar/gtk.py b/lib/solaar/gtk.py
+--- a/lib/solaar/gtk.py
++++ b/lib/solaar/gtk.py
+@@ -175,6 +175,11 @@
+     gi = _require("gi", "python3-gi (in Ubuntu) or python3-gobject (in Fedora)")
+     _require("gi.repository.Gtk", "gir1.2-gtk-3.0", gi, "Gtk", "3.0")
+
++    flatpak_id = os.environ.get("FLATPAK_ID")
++    if flatpak_id:
++        from gi.repository import GLib
++        GLib.set_prgname(flatpak_id)
++
+     # handle ^C in console
+     signal.signal(signal.SIGINT, signal.SIG_DFL)
+     signal.signal(signal.SIGINT, _handlesig)
 diff --git a/lib/solaar/ui/about/view.py b/lib/solaar/ui/about/view.py
 index 4c0d9084..65f90fe0 100644
 --- a/lib/solaar/ui/about/view.py


### PR DESCRIPTION
Fixes my own issue: https://github.com/flathub/io.github.pwr_solaar.solaar/issues/62

I investigated the issue and updating `fix-icon.patch`  fixed it:

<img width="1920" height="1010" alt="Image" src="https://github.com/user-attachments/assets/a0735608-b9c3-4ed1-bc26-cf68f5debfa4" />

<img width="774" height="456" alt="Image" src="https://github.com/user-attachments/assets/2f748b36-8bda-43a4-aff8-9a33127d68c2" />

I tested this patch on Ubuntu 26.04 and no regression there (works fine with/without patch):
<img width="883" height="378" alt="Image" src="https://github.com/user-attachments/assets/2b6aa856-30fa-4a3b-b3a1-d276b14b4690" />